### PR TITLE
soe: change `FlagProtocol` to match `default` typing

### DIFF
--- a/worlds/soe/options.py
+++ b/worlds/soe/options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, fields
-from typing import Any, cast, Dict, Iterator, List, Literal, Tuple, Protocol
+from typing import Any, cast, Dict, Iterator, List, Literal, Tuple, Protocol, Union
 
 from Options import AssembleOptions, Choice, DeathLink, DefaultOnToggle, PerGameCommonOptions, ProgressionBalancing, \
     Range, Toggle
@@ -13,7 +13,7 @@ class FlagsProtocol(Protocol):
 
 class FlagProtocol(Protocol):
     value: int
-    default: int | Literal["random"]
+    default: Union[int, Literal["random"]]
     flag: str
 
 

--- a/worlds/soe/options.py
+++ b/worlds/soe/options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, fields
-from typing import Any, cast, Dict, Iterator, List, Tuple, Protocol
+from typing import Any, cast, Dict, Iterator, List, Literal, Tuple, Protocol
 
 from Options import AssembleOptions, Choice, DeathLink, DefaultOnToggle, PerGameCommonOptions, ProgressionBalancing, \
     Range, Toggle
@@ -8,13 +8,12 @@ from Options import AssembleOptions, Choice, DeathLink, DefaultOnToggle, PerGame
 # typing boilerplate
 class FlagsProtocol(Protocol):
     value: int
-    default: int
     flags: List[str]
 
 
 class FlagProtocol(Protocol):
     value: int
-    default: int
+    default: int | Literal["random"]
     flag: str
 
 


### PR DESCRIPTION
## What is this fixing or adding?

change `FlagProtocol` to match `default` typing for PR https://github.com/ArchipelagoMW/Archipelago/pull/2173

(and `default` isn't needed in `FlagsProtocol`)


This wouldn't be needed if we could use `ReadOnly` in protocols (as mentioned in one line of PEP 705.
It should be
```python3
    value: ReadOnly[object]
    default: ReadOnly[object]
```
since the the types of those don't matter at all for `FlagProtocol`

But we don't have `ReadOnly` yet, so LSP says the typing has to match `Option`.

## How was this tested?

mypy, pyright
