### PR TITLE
FF6WC: Remove ArchplgoItem from shops

### DIFF
--- a/worlds/ff6wc/WorldsCollide/data/shops.py
+++ b/worlds/ff6wc/WorldsCollide/data/shops.py
@@ -226,6 +226,8 @@ class Shops():
             exclude.append(self.items.get_id("Exp. Egg"))
         if self.args.shops_no_illuminas:
             exclude.append(self.items.get_id("Illumina"))
+        # for AP seeds, do NOT include ArchplgoItem b/c it's confusing and not necessary to sell Rename Cards anyways
+        exclude.append(self.items.get_id("ArchplgoItem"))
 
         for shop in self.shops:
             for item in exclude:

--- a/worlds/ff6wc/changes-to-WC-module.txt
+++ b/worlds/ff6wc/changes-to-WC-module.txt
@@ -20,3 +20,5 @@ event/veldt.py add an else clause for an item reward in the case of an AP item s
 72a2792f1034e1b3fd4b76b9e3d94cda43ea6c98 fix portraits/sprites/colors/palettes for linux apworld
 98d78981f7d86b32fd64c0aba30e28e060082869 rework portraits/sprites/colors/palettes again
 ff94786347c1eda76a5308f139028e3153a45236 better avoiding `exit` from `ArgumentParser` and some type annotations
+
+d655902ef0dd14f7f55f4a58400c1c2a94f989fd removing ArchplgoItem from shops in data/shops.py


### PR DESCRIPTION
## What is this fixing or adding?
The implementation of the AP version of FF6WC required that an item be sent for processing to work correctly. The original implementer chose to alter the RenameCard, an item which allows you to rename characters but has no other inherent gameplay functionality, to be the ArchplgoItem which is what is used to pass rewards to the FF6WC player and is collected by them to send to other players.
When this item that had been re-purposed from the RenameCard showed up in shops, this was very confusing for newer players as they may have thought that they needed to purchase the item to complete a check, however, that is not the case since it's not actually a check, just a repurposed item. Removing them from shops avoids any confusion and does not detract from any gameplay.

## How was this tested?
Unfortunately, AP's spoiler log file at Generate time does NOT include all of the log functions for the FF6WC game, and it appears at Launcher time, this .txt file is never generated, so I had to put this code into the WorldsCollide base and test using this spoiler log. I updated the flagstring to include the -sl flag to print a spoiler log when seeds were generated. I verified that the RenameCard does NOT appear in any shops, which would be the ArchplgoItem in the other version of the code.

## If this makes graphical changes, please attach screenshots.
