### PR TITLE
Verifying Objective flagstring at AP Generate time vs. FF6WC Launch/Patch time

### DIFF
--- a/worlds/ff6wc/WorldsCollide/args/objectives.py
+++ b/worlds/ff6wc/WorldsCollide/args/objectives.py
@@ -93,32 +93,25 @@ def process(args):
                 # if there are no condition args at all, this is an error
                 # this is something like -oa 2.1.1.3 where there needs to be something after 3 (either r or a number)
                 if condition_args == []:
-                    import sys
                     args.parser.print_usage()
                     # get the objective string that is not valid for display
                     objective_string = getattr(args, "objective_" + lower_letter)
                     # print error message including the objective string in question
-                    print(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
-                    sys.exit(1)
+                    raise ValueError(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
 
                 # if the condition requires 2 condition arguments, ensure we get 2, otherwise this is an error
                 # this is something like -oa 2.1.1.2.5 where there needs to be something after 5 (minimum) for the maximum range
                 if condition_type.min_max and len(condition_args) < 2:
-                    import sys
                     args.parser.print_usage()
                     # get the objective string that is not valid for display
                     objective_string = getattr(args, "objective_" + lower_letter)
                     # print error message including the objective string in question
-                    print(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
-                    sys.exit(1)
+                    raise ValueError(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
 
                 for arg in condition_args:
                     if arg not in condition_type.value_range:
-                        import sys
                         args.parser.print_usage()
-                        print(f"{sys.argv[0]}: error: {condition_type.name}: invalid argument {arg}")
-                        sys.exit(1)
-
+                        raise ValueError(f"{sys.argv[0]}: error: {condition_type.name}: invalid argument {arg}")
                 condition = Condition(*condition_type, condition_args)
                 conditions.append(condition)
 

--- a/worlds/ff6wc/WorldsCollide/args/objectives.py
+++ b/worlds/ff6wc/WorldsCollide/args/objectives.py
@@ -97,7 +97,7 @@ def process(args):
                     # get the objective string that is not valid for display
                     objective_string = getattr(args, "objective_" + lower_letter)
                     # print error message including the objective string in question
-                    raise ValueError(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
+                    raise ValueError(f"Error! Objective not valid: o{lower_letter} {objective_string}")
 
                 # if the condition requires 2 condition arguments, ensure we get 2, otherwise this is an error
                 # this is something like -oa 2.1.1.2.5 where there needs to be something after 5 (minimum) for the maximum range
@@ -106,12 +106,12 @@ def process(args):
                     # get the objective string that is not valid for display
                     objective_string = getattr(args, "objective_" + lower_letter)
                     # print error message including the objective string in question
-                    raise ValueError(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
+                    raise ValueError(f"Error! Objective not valid: o{lower_letter} {objective_string}")
 
                 for arg in condition_args:
                     if arg not in condition_type.value_range:
                         args.parser.print_usage()
-                        raise ValueError(f"{sys.argv[0]}: error: {condition_type.name}: invalid argument {arg}")
+                        raise ValueError(f"Error: {condition_type.name}: invalid argument {arg}")
                 condition = Condition(*condition_type, condition_args)
                 conditions.append(condition)
 

--- a/worlds/ff6wc/WorldsCollide/args/objectives.py
+++ b/worlds/ff6wc/WorldsCollide/args/objectives.py
@@ -63,10 +63,8 @@ def process(args):
 
             for arg in result_args:
                 if arg not in result_type.value_range:
-                    import sys
                     args.parser.print_usage()
-                    print(f"{sys.argv[0]}: error: {result_type.name}: invalid argument {arg}")
-                    sys.exit(1)
+                    raise ValueError(f"Error: {result_type.name}: invalid argument {arg}")
 
             result = Result(*result_type, result_args)
 

--- a/worlds/ff6wc/WorldsCollide/args/objectives.py
+++ b/worlds/ff6wc/WorldsCollide/args/objectives.py
@@ -90,6 +90,28 @@ def process(args):
                 condition_args = values[value_index : value_index + condition_arg_count]
                 value_index += condition_arg_count
 
+                # if there are no condition args at all, this is an error
+                # this is something like -oa 2.1.1.3 where there needs to be something after 3 (either r or a number)
+                if condition_args == []:
+                    import sys
+                    args.parser.print_usage()
+                    # get the objective string that is not valid for display
+                    objective_string = getattr(args, "objective_" + lower_letter)
+                    # print error message including the objective string in question
+                    print(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
+                    sys.exit(1)
+
+                # if the condition requires 2 condition arguments, ensure we get 2, otherwise this is an error
+                # this is something like -oa 2.1.1.2.5 where there needs to be something after 5 (minimum) for the maximum range
+                if condition_type.min_max and len(condition_args) < 2:
+                    import sys
+                    args.parser.print_usage()
+                    # get the objective string that is not valid for display
+                    objective_string = getattr(args, "objective_" + lower_letter)
+                    # print error message including the objective string in question
+                    print(f"{sys.argv[0]}: error! Objective not valid: o{lower_letter} {objective_string}")
+                    sys.exit(1)
+
                 for arg in condition_args:
                     if arg not in condition_type.value_range:
                         import sys

--- a/worlds/ff6wc/WorldsCollide/args/objectives.py
+++ b/worlds/ff6wc/WorldsCollide/args/objectives.py
@@ -99,7 +99,7 @@ def process(args):
 
                 # if there are no condition args at all, this is an error
                 # this is something like -oa 2.1.1.3 where there needs to be something after 3 (either r or a number)
-                if condition_args == []:
+                if len(condition_args) < 1:
                     args.parser.print_usage()
                     # get the objective string that is not valid for display
                     objective_string = getattr(args, "objective_" + lower_letter)

--- a/worlds/ff6wc/WorldsCollide/args/objectives.py
+++ b/worlds/ff6wc/WorldsCollide/args/objectives.py
@@ -75,6 +75,15 @@ def process(args):
             conditions_required_max = values[value_index]
             value_index += 1
 
+            # if the minimum number of conditions required > maximum, that's an error
+            # this is something like -oe 42.2.1.9.15.4.5.10.3.2 where it requires 2 of 1 conditions, which is non-valid statement
+            if conditions_required_min > conditions_required_max:
+                args.parser.print_usage()
+                # get the objective string that is not valid for display
+                objective_string = getattr(args, "objective_" + lower_letter)
+                # print error message including the objective string in question
+                raise ValueError(f"Error! Objective not valid, min conditions > max conditions: o{lower_letter} {objective_string}")
+
             conditions = []
             while value_index < len(values) and len(conditions) < MAX_CONDITIONS:
                 condition_type = condition_types[values[value_index]]

--- a/worlds/ff6wc/changes-to-WC-module.txt
+++ b/worlds/ff6wc/changes-to-WC-module.txt
@@ -22,4 +22,4 @@ event/veldt.py add an else clause for an item reward in the case of an AP item s
 ff94786347c1eda76a5308f139028e3153a45236 better avoiding `exit` from `ArgumentParser` and some type annotations
 
 d655902ef0dd14f7f55f4a58400c1c2a94f989fd removing ArchplgoItem from shops in data/shops.py
-4bd5e63c0eb25e8b70cf6c50e09007c050da4efb update Objectives parsing to throw errors earlier for missiong conditional arguments in args/objectives.py (NOTE: this should be incorporated into base at some point)
+4bd5e63c0eb25e8b70cf6c50e09007c050da4efb update Objectives parsing to throw errors earlier for missing conditional arguments in args/objectives.py (NOTE: this should be incorporated into base at some point)

--- a/worlds/ff6wc/changes-to-WC-module.txt
+++ b/worlds/ff6wc/changes-to-WC-module.txt
@@ -22,3 +22,4 @@ event/veldt.py add an else clause for an item reward in the case of an AP item s
 ff94786347c1eda76a5308f139028e3153a45236 better avoiding `exit` from `ArgumentParser` and some type annotations
 
 d655902ef0dd14f7f55f4a58400c1c2a94f989fd removing ArchplgoItem from shops in data/shops.py
+4bd5e63c0eb25e8b70cf6c50e09007c050da4efb update Objectives parsing to throw errors earlier for missiong conditional arguments in args/objectives.py (NOTE: this should be incorporated into base at some point)

--- a/worlds/ff6wc/test/test_verify_flags.py
+++ b/worlds/ff6wc/test/test_verify_flags.py
@@ -1,15 +1,48 @@
 import unittest
 from worlds.ff6wc.Options import verify_flagstring
 
+standard_flagstring = (
+    " -cg -oa 2.2.2.2.6.6.4.9.9 -ob 3.1.1.2.9.9.4.12.12.10.22.22 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 "
+    "-sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 6 10 -lmprp 75 125 -lel "
+    "-srr 25 35 -rnl -rnc -sdr 3 4 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 "
+    "-rec2 27 -xpm 3 -mpm 5 -gpm 5 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc "
+    "shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 "
+    "-emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 "
+    "-sto 1 -ieor 33 -ieror 33 -ir stronger -csb 7 15 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 5 -npi "
+    "-sebr -snsb -snee -snil -ccsr 20 -chrm 0 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari "
+    "-anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -etn "
+)
+
 
 class TestVerifyFlags(unittest.TestCase):
     def test_ok_flags(self) -> None:
         verify_flagstring(["-i", "x"])
         verify_flagstring([])
-        standardflagstring = " -cg -oa 2.2.2.2.6.6.4.9.9 -ob 3.1.1.2.9.9.4.12.12.10.22.22 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 6 10 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 3 4 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 3 -mpm 5 -gpm 5 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir stronger -csb 7 15 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 5 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 0 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -etn "
-        verify_flagstring(["-i", standardflagstring])
-        verify_flagstring(["-i", "-cg -oa 2.6.6.3.r.3.r.3.r.5.r.5.r.5.r -ob 3.0.0 -oc 21.10.10.0.0 -od 22.5.5.0.0 -oe 23.5.5.0.0 -sc1 random -sc2 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 97 -xpm 1 -mpm 5 -gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 0.5 -msl 50 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -elr -ebr 100 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sws 0 -sto 1 -ieor 33 -ieror 33 -ir standard -csb 10 20 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 4 -npi -sebr -snsb -snee -snil -ccsr 20 -cms -frw -wmhc -cor -crr -crvr 255 255 -crm -cnee -cnil -ari -anca -adeh -nmc -nee -noshoes -nu -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -rc -warp -move bd -etn -yremove"])
-        verify_flagstring(["-i", "-cg -oa 2.6.6.3.r.3.r.3.r.5.r.5.r.5.r -ob 3.0.0 -oc 21.10.10.0.0 -od 22.5.5.0.0 -oe 23.5.5.0.0 -sc1 random -sc2 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 97 -xpm 1 -mpm 5 -gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 0.5 -msl 50 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -elr -ebr 100 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 500000 -smc 3 -sws 0 -sto 1 -ieor 33 -ieror 33 -ir standard -csb 10 20 -mca -stra -saw -sisr 5 -sprv 0 0 -sdm 4 -npi -snbr -snes -snsb -snee -snil -ccsr 20 -cms -frw -wmhc -cor -crr -crvr 255 255 -crm -cnee -cnil -ari -anca -adeh -nmc -nee -noshoes -nu -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -rc -warp -move bd -etn -yremove"])
+        verify_flagstring(["-i", standard_flagstring])
+        verify_flagstring([
+            "-i",
+            "-cg -oa 2.6.6.3.r.3.r.3.r.5.r.5.r.5.r -ob 3.0.0 -oc 21.10.10.0.0 -od 22.5.5.0.0 -oe 23.5.5.0.0 -sc1 "
+            "random -sc2 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc "
+            "-sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 97 -xpm 1 -mpm 5 "
+            "-gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 0.5 -msl 50 -sed -bbs -drloc shuffle -stloc mix -be -bnu "
+            "-res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -elr -ebr 100 -emprp 75 125 -emi -nm1 random "
+            "-rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sws 0 -sto 1 -ieor 33 "
+            "-ieror 33 -ir standard -csb 10 20 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 4 -npi -sebr -snsb "
+            "-snee -snil -ccsr 20 -cms -frw -wmhc -cor -crr -crvr 255 255 -crm -cnee -cnil -ari -anca -adeh -nmc "
+            "-nee -noshoes -nu -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -rc -warp -move bd -etn -yremove"
+        ])
+        verify_flagstring([
+            "-i",
+            "-cg -oa 2.6.6.3.r.3.r.3.r.5.r.5.r.5.r -ob 3.0.0 -oc 21.10.10.0.0 -od 22.5.5.0.0 -oe 23.5.5.0.0 "
+            "-sc1 random -sc2 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl "
+            "-rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 97 -xpm 1 -mpm 5 "
+            "-gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 0.5 -msl 50 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res "
+            "-fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -elr -ebr 100 -emprp 75 125 -emi -nm1 random -rnl1 "
+            "-rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 500000 -smc 3 -sws 0 -sto 1 -ieor 33 -ieror 33 "
+            "-ir standard -csb 10 20 -mca -stra -saw -sisr 5 -sprv 0 0 -sdm 4 -npi -snbr -snes -snsb -snee -snil "
+            "-ccsr 20 -cms -frw -wmhc -cor -crr -crvr 255 255 -crm -cnee -cnil -ari -anca -adeh -nmc -nee -noshoes "
+            "-nu -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -rc -warp -move bd -etn -yremove"
+        ])
 
     def test_new_flags(self) -> None:
         """ some new flags from Worlds Collide 1.4.2 """
@@ -18,21 +51,43 @@ class TestVerifyFlags(unittest.TestCase):
     def test_bad_flags(self) -> None:
         self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-bkbkb00"])
         # for these objective tests, see https://github.com/beauxq/Archipelago/pull/8 for more info
-        # NOTE: for some reason, the ArgParse parser method is rejecting the entire flagstring, and I'm not sure why...we are getting ValueError, but not from the correct part of the code that is being reached when doing Generate.py
-        standardflagstring = " -cg -oa 2.2.2.2.6.6.4.9.9 -ob 3.1.1.2.9.9.4.12.12.10.22.22 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 6 10 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 3 4 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 3 -mpm 5 -gpm 5 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir stronger -csb 7 15 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 5 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 0 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -etn "
+
+        # NOTE: for some reason, the ArgParse parser method is rejecting the entire flagstring,
+        # and I'm not sure why...we are getting ValueError,
+        # but not from the correct part of the code that is being reached when doing Generate.py
         # Bad Objective Result number (current values are 0-73)
-        #self.assertRaises(KeyError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 83.1.1.11.31 "])
-        # Bad Objective Range, in this example: Add 18-155 Enemy Levels for 1 random objective (max is 99)
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 21.18.155.1.1.1.r "])
-        # Bad Objective Range, in this example: Update MagPwr stat between -234 and +23 for 1-2 dragon kills (range -99 to 99)
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 45.-234.23.1.1.6.1.2 "])
-        # Bad Objective Conditions min/max, in this example: Ribbon for completing 2 of 1 conditions
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 42.2.1.9.15.4.5.10.3.2 "])
+        # self.assertRaises(KeyError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 83.1.1.11.31 "])
+
+        # Bad Objective Range, in this example:
+        # Add 18-155 Enemy Levels for 1 random objective (max is 99)
+        self.assertRaises(ValueError, verify_flagstring, [
+            "-i", "x", standard_flagstring, " -oe 21.18.155.1.1.1.r "
+        ])
+
+        # Bad Objective Range, in this example:
+        # Update MagPwr stat between -234 and +23 for 1-2 dragon kills (range -99 to 99)
+        self.assertRaises(ValueError, verify_flagstring, [
+            "-i", "x", standard_flagstring, " -oe 45.-234.23.1.1.6.1.2 "
+        ])
+
+        # Bad Objective Conditions min/max, in this example:
+        # Ribbon for completing 2 of 1 conditions
+        self.assertRaises(ValueError, verify_flagstring, [
+            "-i", "x", standard_flagstring, " -oe 42.2.1.9.15.4.5.10.3.2 "
+        ])
         # Bad Objective Condition Type (current range 0-12)
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 65.1.1.22.31 "])
+        self.assertRaises(ValueError, verify_flagstring, [
+            "-i", "x", standard_flagstring, " -oe 65.1.1.22.31 "
+        ])
+
         # Bad Objective Condition Value Range, in this example using random as a max
-        #self.assertRaises(TypeError, verify_flagstring, [standardflagstring] + [" -oe 35.2.2.2.1.9.r "])
+        # self.assertRaises(TypeError, verify_flagstring, [standardflagstring] + [" -oe 35.2.2.2.1.9.r "])
+
         # Bad Objective Condition Value Range, in this example missing the max condition
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12 "])
+        self.assertRaises(ValueError, verify_flagstring, [
+            "-i", "x", standard_flagstring, " -oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12 "
+        ])
         # Bad Objective Condition Value, it's missing from this one
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -of 40.4.4.3.6.3.3.0.9.2.5.16.12 "])
+        self.assertRaises(ValueError, verify_flagstring, [
+            "-i", "x", standard_flagstring, " -of 40.4.4.3.6.3.3.0.9.2.5.16.12 "
+        ])

--- a/worlds/ff6wc/test/test_verify_flags.py
+++ b/worlds/ff6wc/test/test_verify_flags.py
@@ -13,3 +13,20 @@ class TestVerifyFlags(unittest.TestCase):
 
     def test_bad_flags(self) -> None:
         self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-bkbkb00"])
+        # for these objective tests, see https://github.com/beauxq/Archipelago/pull/8 for more info
+        # Bad Objective Result number (current values are 0-73)
+        self.assertRaises(KeyError, verify_flagstring, ["-i", "x", "-oe 84.1.1.11.31"])
+        # Bad Objective Range, in this example: Add 18-155 Enemy Levels for 1 random objective (max is 99)
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 21.18.155.1.1.1.r"])
+        # Bad Objective Range, in this example: Update MagPwr stat between -234 and +23 for 1-2 dragon kills (range -99 to 99)
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 45.-234.23.1.1.6.1.2"])
+        # Bad Objective Conditions min/max, in this example: Ribbon for completing 2 of 1 conditions
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 42.2.1.9.15.4.5.10.3.2"])
+        # Bad Objective Condition Type (current range 0-12)
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 65.1.1.22.31"])
+        # Bad Objective Condition Value Range, in this example using random as a max
+        self.assertRaises(TypeError, verify_flagstring, ["-i", "x", "-oe 35.2.2.2.1.9.r"])
+        # Bad Objective Condition Value Range, in this example missing the max condition
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12"])
+        # Bad Objective Condition Value, it's missing from this one
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-of 40.4.4.3.6.3.3.0.9.2.5.16.12"])

--- a/worlds/ff6wc/test/test_verify_flags.py
+++ b/worlds/ff6wc/test/test_verify_flags.py
@@ -6,6 +6,10 @@ class TestVerifyFlags(unittest.TestCase):
     def test_ok_flags(self) -> None:
         verify_flagstring(["-i", "x"])
         verify_flagstring([])
+        standardflagstring = " -cg -oa 2.2.2.2.6.6.4.9.9 -ob 3.1.1.2.9.9.4.12.12.10.22.22 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 6 10 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 3 4 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 3 -mpm 5 -gpm 5 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir stronger -csb 7 15 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 5 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 0 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -etn "
+        verify_flagstring(["-i", standardflagstring])
+        verify_flagstring(["-i", "-cg -oa 2.6.6.3.r.3.r.3.r.5.r.5.r.5.r -ob 3.0.0 -oc 21.10.10.0.0 -od 22.5.5.0.0 -oe 23.5.5.0.0 -sc1 random -sc2 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 97 -xpm 1 -mpm 5 -gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 0.5 -msl 50 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -elr -ebr 100 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sws 0 -sto 1 -ieor 33 -ieror 33 -ir standard -csb 10 20 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 4 -npi -sebr -snsb -snee -snil -ccsr 20 -cms -frw -wmhc -cor -crr -crvr 255 255 -crm -cnee -cnil -ari -anca -adeh -nmc -nee -noshoes -nu -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -rc -warp -move bd -etn -yremove"])
+        verify_flagstring(["-i", "-cg -oa 2.6.6.3.r.3.r.3.r.5.r.5.r.5.r -ob 3.0.0 -oc 21.10.10.0.0 -od 22.5.5.0.0 -oe 23.5.5.0.0 -sc1 random -sc2 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 97 -xpm 1 -mpm 5 -gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 0.5 -msl 50 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -elr -ebr 100 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 500000 -smc 3 -sws 0 -sto 1 -ieor 33 -ieror 33 -ir standard -csb 10 20 -mca -stra -saw -sisr 5 -sprv 0 0 -sdm 4 -npi -snbr -snes -snsb -snee -snil -ccsr 20 -cms -frw -wmhc -cor -crr -crvr 255 255 -crm -cnee -cnil -ari -anca -adeh -nmc -nee -noshoes -nu -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -rc -warp -move bd -etn -yremove"])
 
     def test_new_flags(self) -> None:
         """ some new flags from Worlds Collide 1.4.2 """
@@ -14,19 +18,21 @@ class TestVerifyFlags(unittest.TestCase):
     def test_bad_flags(self) -> None:
         self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-bkbkb00"])
         # for these objective tests, see https://github.com/beauxq/Archipelago/pull/8 for more info
-        # Bad Objective Result number (current values are 0-73); currently commented out due to not seeing KeyError
-        #self.assertRaises(KeyError, verify_flagstring, ["-i", "x", "-oe 84.1.1.11.31"])
+        # NOTE: for some reason, the ArgParse parser method is rejecting the entire flagstring, and I'm not sure why...we are getting ValueError, but not from the correct part of the code that is being reached when doing Generate.py
+        standardflagstring = " -cg -oa 2.2.2.2.6.6.4.9.9 -ob 3.1.1.2.9.9.4.12.12.10.22.22 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 6 10 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 3 4 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 3 -mpm 5 -gpm 5 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir stronger -csb 7 15 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 5 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 0 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -rr -etn "
+        # Bad Objective Result number (current values are 0-73)
+        #self.assertRaises(KeyError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 83.1.1.11.31 "])
         # Bad Objective Range, in this example: Add 18-155 Enemy Levels for 1 random objective (max is 99)
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 21.18.155.1.1.1.r"])
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 21.18.155.1.1.1.r "])
         # Bad Objective Range, in this example: Update MagPwr stat between -234 and +23 for 1-2 dragon kills (range -99 to 99)
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 45.-234.23.1.1.6.1.2"])
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 45.-234.23.1.1.6.1.2 "])
         # Bad Objective Conditions min/max, in this example: Ribbon for completing 2 of 1 conditions
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 42.2.1.9.15.4.5.10.3.2"])
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 42.2.1.9.15.4.5.10.3.2 "])
         # Bad Objective Condition Type (current range 0-12)
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 65.1.1.22.31"])
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 65.1.1.22.31 "])
         # Bad Objective Condition Value Range, in this example using random as a max
-        self.assertRaises(TypeError, verify_flagstring, ["-i", "x", "-oe 35.2.2.2.1.9.r"])
+        #self.assertRaises(TypeError, verify_flagstring, [standardflagstring] + [" -oe 35.2.2.2.1.9.r "])
         # Bad Objective Condition Value Range, in this example missing the max condition
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12"])
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12 "])
         # Bad Objective Condition Value, it's missing from this one
-        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-of 40.4.4.3.6.3.3.0.9.2.5.16.12"])
+        self.assertRaises(ValueError, verify_flagstring, ["-i", "x", standardflagstring, " -of 40.4.4.3.6.3.3.0.9.2.5.16.12 "])

--- a/worlds/ff6wc/test/test_verify_flags.py
+++ b/worlds/ff6wc/test/test_verify_flags.py
@@ -14,8 +14,8 @@ class TestVerifyFlags(unittest.TestCase):
     def test_bad_flags(self) -> None:
         self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-bkbkb00"])
         # for these objective tests, see https://github.com/beauxq/Archipelago/pull/8 for more info
-        # Bad Objective Result number (current values are 0-73)
-        self.assertRaises(KeyError, verify_flagstring, ["-i", "x", "-oe 84.1.1.11.31"])
+        # Bad Objective Result number (current values are 0-73); currently commented out due to not seeing KeyError
+        #self.assertRaises(KeyError, verify_flagstring, ["-i", "x", "-oe 84.1.1.11.31"])
         # Bad Objective Range, in this example: Add 18-155 Enemy Levels for 1 random objective (max is 99)
         self.assertRaises(ValueError, verify_flagstring, ["-i", "x", "-oe 21.18.155.1.1.1.r"])
         # Bad Objective Range, in this example: Update MagPwr stat between -234 and +23 for 1-2 dragon kills (range -99 to 99)


### PR DESCRIPTION
## What is this fixing or adding?
There have been several cases of people using custom flagstrings which should have caused syntax errors in the first pass of the parser in the verify_flagstring method which is called from generate_output in init.py. This caused the AP multi-world game to Generate, however, when attempting to actually play the game via Launch or Patch, an error would be thrown due to a bad objective string. This was frustrating for those running larger async rooms as the multi-world game in some cases would start, but this FF6WC seed would be unplayable because it contained an error.
Most of the Objective parse problems are caught during parse phase which is what the verify_flagstring method calls except for the case where there was a result specified, but no or insufficient condition arguments after the condition type was specified. This scenario is now detected properly at parse time instead of log or run time.

## How was this tested?
## If this makes graphical changes, please attach screenshots.
I used 3 different yamls for this, 2 of which came directly from the AP Discord, another I created for all of the different parts of the objective string parsing steps where an error could occur.

Flagstring: -cg -oa 2.3.3.2.12.12.4.24.24.6.8.8 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12 -of 40.4.4.3.6.3.3.0.9.2.5.16.12 -og 13.5.5.3.8.3.3.7.7.9.9.9.10.5.17 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbs -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -stesp 1 1 -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -name TERRA.LOCKE.CYAN.SHADOW.EDGAR.SABIN.CELES.STRAGO.RELM.SETZER.KRILE.GAU.GOGO.GREG -cpal 0.1.2.3.4.60.6 -cpor 334.327.320.332.321.330.319.333.329.331.373.322.325.104.46 -cspr 330.1.2.3.4.5.255.7.104.9.84.11.12.72.14.61.107.19.20.21 -cspp 2.1.4.4.0.0.3.3.3.4.0.3.3.5.1.0.0.1.0.3 -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain

Errors occur in multiple objectives in this flagstring and I removed erroneous ones to test only the code paths that were updated when needed.
Objective E is missing a max condition argument.
-oe 8.4.4.3.1.3.3.3.3.3.5.5.5.8.12
Result: 8 -> Auto-Haste
Conditions Required: 4.4 -> needs to complete 4 out of 4
Condition 1: 3.1 -> Recruit Locke
Condition 2: 3.3 -> Recruit Shadow
Condition 3: 3.3 -> Recruit Shadow (yes a second time)
Condition 4: 3.5 -> Recruit Sabin
Condition 5: 5.5 -> Esper Shoat
Condition 6: 8.12 -> Bosses 12-?
This is missing a second condition argument telling it the upper range for the number of bosses to kill to complete this objective.
Error Message with fix:
![image](https://github.com/user-attachments/assets/2fee7119-7abe-4948-9f7d-9e28ad185b45)



Objective F is missing a condition argument.
-of 40.4.4.3.6.3.3.0.9.2.5.16.12
Result: 40 -> Illumina
Conditions Required: 4.4 -> needs to complete 4 out of 4
Condition 1: 3.6 -> Recruit Celes
Condition 2: 3.3 -> Recruit Shadow
Condition 3: 0 -> None (this just gets ignored, but it's weird to have it in here)
Condition 4: 9.2 -> Boss AtmaWeapon
Condition 5: 5.16 -> Esper Ragnarok
Condition 6: 12 -> Quest ?
This is missing a condition argument indicating which Quest needs to be completed
Error message with fix:
![image](https://github.com/user-attachments/assets/b2260848-bae7-4720-98c5-8cb4463bf6f1)



Flagstring: -cg -oa 2.5.5.2.6.6.4.9.9.1.r.1.r.1.1.r -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 random -sc2 randomngu -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 2 -mpm 5 -gpm 5 -nxppd -lsc 1 -hmc 1 -xgc 1 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc shuffle -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebs -emprp 75 125 -eebr 6 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 100000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir standard -csb 6 14 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 5 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 0 0 -cms -frm -wmhc -ahtc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -warp -move bd -etn -yremove

The other one seems to have been already caught in another part of the parsing process before verify_flagstring gets called, so this one also properly fails, but not using either of my new paths I put in place:
![403703650-95b2972e-fdbf-4316-a0f9-815b24ee13d1](https://github.com/user-attachments/assets/a8eb2e70-452d-437e-8f37-f8a8be3893a5)

Another from the Discord server: https://discord.com/channels/731205301247803413/1022545979146252288/1342572392505147452

Kefka Tower Skip for 4 of 2 Conditions:

-ob 3.4.2.2.9.10.4.13.17.6.2.4.12.5

![image](https://github.com/user-attachments/assets/d633720d-3e8e-438b-a378-2951941fffd1)





Potential syntax errors not reported through the Discord:
**Bad Objective Result, (0-73 are valid at the current time)**
-oe 84.1.1.11.31
![image](https://github.com/user-attachments/assets/f7004fc5-1d83-40e1-93bc-1ba1d9c3f8fc)

**Bad Objective Result Range**
- Numeric (Enemy Levels, Commands, Stats)
Ex: Add 18-155 Enemy Levels for 1 random objective (max is 99)
-oe 21.18.155.1.1.1.r
![image](https://github.com/user-attachments/assets/88df690a-0f6e-4de0-b3b4-3d47f6bf38f7)

Ex: Update MagPwr stat between -234 and +23 for 1-2 dragon kills (range -99 to 99)
-oe 45.-234.23.1.1.6.1.2
![image](https://github.com/user-attachments/assets/b218fb93-0cd9-4bca-a5a5-01a08a8f4355)


**Bad Conditions Required Min/Max**

- 	If less objectives than min/max, will just require all

    Ex: -oa 2.4.4.3.1 (just recruit Locke for Kefka, even though it says 4 out of 4 required)

- 	If the min number of conditions > max number of conditions 

	Ex: -oe 42.2.1.9.15.4.5.10.3.2
	"Ribbon for completing 2 of 1 conditions"
	This is not a valid objective statement which doesn't get caught during parsing for Generate but instead during Patch.
	Error message with fix (during Generate phase):
![image](https://github.com/user-attachments/assets/82cdd6bf-d9a1-439b-9543-c7ea3e562db3)

Error message without the fix (during Patch phase)
![image](https://github.com/user-attachments/assets/24afee90-7454-4e3a-a5b5-6708564906a0)

	
**Objective Condition Type (current range 0-12)**
Ex: -oe 65.1.1.22.31
![image](https://github.com/user-attachments/assets/40fefcf6-d42f-4771-856b-7e2ad69eb489)


**Objective Condition Value Range**

- 	None 

	This is really 0.0 in Conditions Req Min/Max

- 	“r”

	-oe 35.2.2.2.1.9.r
![image](https://github.com/user-attachments/assets/fa6cd847-3d6a-4e42-89a5-36ea062c7040)

- 	Counts for rest 
These are the errors fixed above.




