### PR TITLE
prevent random boss + Unlock Kefka requirements from softlocks

### DIFF
--- a/worlds/ff6wc/Options.py
+++ b/worlds/ff6wc/Options.py
@@ -458,17 +458,6 @@ def generate_objectives_string(options: FF6WCOptions) -> List[str]:
     character_count = options.CharacterCount
     esper_count = options.EsperCount
     dragon_count = options.DragonCount
-
-    # randomized bosses can make it so not enough bosses are available for kefka requirement
-    # A proper fix for this needs to be in the WorldsCollide code,
-    # but a workaround here can make it really unlikely that this problem occurs
-    # TODO: remove this workaround when it's fixed in WorldsCollide code (and that version of WC is here in AP)
-    # https://discord.com/channels/666661907628949504/1235621693381410906
-    if options.RandomizedBosses.value == RandomizedBosses.option_randomized:
-        # 18 makes it around 1/85000 if bosses randomized and requirement randomized
-        if options.BossCount.value > 18:
-            options.BossCount.value = 18
-
     boss_count = options.BossCount
 
     # fb = final battle unlock

--- a/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
+++ b/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
@@ -194,18 +194,17 @@ class EnemyPacks():
             # the random boss formation list is a sample of the remaining bosses 
             # for the amount needed to fulfill objectives
             random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
-            # update required boss formations with union of itself & random boss formations
-            required_boss_formations |= set(random_boss_formations)
-            # now we need to separate out any statues that are in the required boss formations at the end
+            # add these boss formations into the appropriate set 
+            # (required_boss_formations or required_statue_formations)
             for formation_id in random_boss_formations:
                 # if this formation is a statue
                 if formation_id in bosses.statue_formation_name:
-                    # remove from regular boss formations
-                    required_boss_formations.remove(formation_id)
-                    # if the formation not currently in the required set
-                    if formation_id not in required_statue_formations:
-                        # add into statue formations
-                        required_statue_formations.add(formation_id)
+                    # add to required statue formations
+                    required_statue_formations.add(formation_id)
+                # else a regular boss
+                else:
+                    # add to required boss formations
+                    required_boss_formations.add(formation_id)
 
         dragon_formations_needed = min_dragon_formations - len(required_dragon_formations)
         if dragon_formations_needed > 0:

--- a/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
+++ b/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
@@ -174,14 +174,15 @@ class EnemyPacks():
                         required_statue_formations.add(formation)
                     else:
                         required_boss_formations.add(formation)
-                # if this condition is a set number of bosses, make sure we always get the highest amount for the minimum req # of formations
                 elif condition.NAME == bosses_condition_name and condition.count > min_boss_formations:
+                    # if this condition is a set number of bosses,
+                    # make sure we always get the highest amount for the minimum req # of formations
                     min_boss_formations = condition.count
                 elif condition.NAME == dragon_condition_name:
                     required_dragon_formations.add(condition.dragon_formation)
                 elif condition.NAME == dragons_condition_name and condition.count > min_dragon_formations:
                     min_dragon_formations = condition.count
-       # amount of bosses needed is the minimum from above minus the required bosses + required statues
+        # amount of bosses needed is the minimum from above minus the required bosses + required statues
         boss_formations_needed = min_boss_formations - (len(required_boss_formations) + len(required_statue_formations))
         # if the extra required number needed non-zero
         if boss_formations_needed > 0:
@@ -190,7 +191,8 @@ class EnemyPacks():
             # remaining bosses is all bosses - required bosses | required statues
             required_formations = set(required_boss_formations | required_statue_formations)
             remaining_boss_formations = list(all_boss_formations - required_formations)
-            # the random boss formation list is a sample of the remaining bosses for the amount needed to fulfill objectives
+            # the random boss formation list is a sample of the remaining bosses
+            # for the amount needed to fulfill objectives
             random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
             # update required boss formations with union of itself & random boss formations
             required_boss_formations |= set(random_boss_formations)

--- a/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
+++ b/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
@@ -189,7 +189,7 @@ class EnemyPacks():
             all_boss_formations = set(bosses.normal_formation_name)
             # remaining bosses is all bosses - required bosses | required statues
             required_formations = set(required_boss_formations | required_statue_formations)
-            remaining_boss_formations = list(all_boss_formations - required_formations)
+            remaining_boss_formations = sorted(all_boss_formations - required_formations)
             # the random boss formation list is a sample of the remaining bosses for the amount needed to fulfill objectives
             random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
             # update required boss formations with union of itself & random boss formations
@@ -208,7 +208,7 @@ class EnemyPacks():
         dragon_formations_needed = min_dragon_formations - len(required_dragon_formations)
         if dragon_formations_needed > 0:
             all_dragon_formations = set(bosses.dragon_formation_name)
-            remaining_dragon_formations = list(all_dragon_formations - required_dragon_formations)
+            remaining_dragon_formations = sorted(all_dragon_formations - required_dragon_formations)
             random_dragon_formations = random.sample(remaining_dragon_formations, dragon_formations_needed)
             required_dragon_formations |= set(random_dragon_formations)
 

--- a/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
+++ b/worlds/ff6wc/WorldsCollide/data/enemy_packs.py
@@ -191,7 +191,7 @@ class EnemyPacks():
             # remaining bosses is all bosses - required bosses | required statues
             required_formations = set(required_boss_formations | required_statue_formations)
             remaining_boss_formations = sorted(all_boss_formations - required_formations)
-            # the random boss formation list is a sample of the remaining bosses 
+            # the random boss formation list is a sample of the remaining bosses
             # for the amount needed to fulfill objectives
             random_boss_formations = random.sample(remaining_boss_formations, boss_formations_needed)
             # update required boss formations with union of itself & random boss formations


### PR DESCRIPTION
## What is this fixing or adding?
Dragon softlock prevention was already in place, but somehow bosses/statues were left out. This PR attempts to prevent a scenario where the Bosses = Random (-bbr flag) and Kefka requires a specific number of bosses for unlock. If this number is very high, there is a possibility that the randomizer doesn't put in enough unique bosses to actually beat the game by unlocking Kefka objective remaining incomplete. We have seen this issue come up in the AP version of the game, which is why there was a workaround in place to limit the boss count to 18 at maximum.

## How was this tested?
Wrote code in data/enemy_packs.py to print out the required boss & statue fights:

```
        print(len(required_boss_formations))
        print(len(required_statue_formations))
        for boss in required_boss_formations:
            print(bosses.normal_formation_name[boss])
        for boss in required_statue_formations:
            print(bosses.normal_formation_name[boss])
```

**Final Kefka objective = 4 bosses + Doom required**
wc.py -i FinalFantasyIII.smc -o ff3b.smc -cg -oa 2.4.4.2.12.12.4.24.24.8.4.4.9.6 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -oe 3.1.1.9.6 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbr -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain
Required Bosses: 3
Required Statues: 1
Vargas
Rizopas
Dullahan
Doom

**Final Kefka objective = 34 bosses + Air Force + Goddess (ensure 1 non-statue boss & 1 statue boss)**
wc.py -i FinalFantasyIII.smc -o ff3b.smc -cg -oa 2.5.5.2.12.12.4.24.24.8.34.34.9.0.9.11 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -oe 3.1.1.9.6 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbr -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain
Required Bosses: 31
Required Statues: 3
Marshal
Phunbaba 3
Phunbaba 4
Whelk
Vargas
TunnelArmr
GhostTrain
Dadaluma
Ifrit/Shiva
Cranes
Number 024
Number 128
Umaro
Guardian
FlameEater
Nerapa
SrBehemoth
Tentacles
Dullahan
Chadarnook
Air Force
Wrexsoul
Rizopas
Hidon
Doom Gaze
Ultros 1
Ultros/Chupon
Atma
MagiMaster
Tritoch
Kefka (Narshe)
Doom
Goddess
Poltrgeist

**Doing it another time gave me 32/2:**
32
2
Ultros 3
Leader
Phunbaba 3
Phunbaba 4
Whelk
TunnelArmr
GhostTrain
Dadaluma
Ifrit/Shiva
Cranes
Number 024
Number 128
Umaro
Guardian
FlameEater
Nerapa
SrBehemoth
Tentacles
Dullahan
Air Force
Stooges
Wrexsoul
Doom Gaze
Rizopas
Hidon
Ultros 1
Ultros 2
Ultros/Chupon
MagiMaster
Inferno
Tritoch
Kefka (Narshe)
Doom
Goddess

**Final Kefka objective = 2 bosses + Guardian + Dadaluma + Poltrgeist (# bosses < # named bosses)**
wc.py -i FinalFantasyIII.smc -o ff3b.smc -cg -oa 2.6.6.2.12.12.4.24.24.8.2.2.9.5.9.24.9.12 -ob 3.1.1.2.9.9.4.12.12.10.21.21 -oc 30.8.8.1.1.11.8 -od 59.1.1.11.31 -sc1 randomngu -sal -sn -eu -csrp 85 130 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 30 -rnl -rnc -sdr 1 1 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -rec3 6 -rec4 24 -rec5 97 -xpm 4 -mpm 4 -gpm 4 -nxppd -lsbd 3 -hmbd 2.5 -xgbd 2 -ase 2 -msl 97 -sed -sfb -bbr -drloc mix -stloc shuffle -be -res -fer 0 -escr 100 -dgne -mmnu -cmd -esr 2 4 -elrt -ebr 80 -emprp 75 125 -emi -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 1 -sto 1 -ieor 40 -ieror 40 -ir standard -csb 20 20 -mca -stra -saw -sisr 15 -sprp 75 120 -sdm 5 -npi -snbr -sebr -snes -snsb -sesb -snee -snil -ccsr 15 -chrm 5 5 -cms -frw -wmhc -ahtc -cor 80 -crr 80 -crvr 100 120 -crm -cnee -cnil -ari -anca -adeh -ame 1 -nmc -nil -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -scan -etn -ymain
2
1
Guardian
Dadaluma
Poltrgeist
