### PR TITLE
Fix duplicate item bug

### DIFF
--- a/worlds/ff6wc/Client.py
+++ b/worlds/ff6wc/Client.py
@@ -332,7 +332,7 @@ class FF6WCClient(SNIClient):
                     if slot == Rom.item_name_id[item_name]:
                         found_slot = i
                         break
-                if found_slot != -1:
+                if found_slot != -1:  # We have this item in inventory, so increment count
                     quantity = item_quantities_data[found_slot]
                     amount = max(min(quantity + 1, 99), 1)
                     self.add_item_to_inventory(ctx,
@@ -341,7 +341,7 @@ class FF6WCClient(SNIClient):
                                                amount,
                                                item_name,
                                                item)
-                else: # Item not in inventory, so we write to a free slot
+                else:  # Item not in inventory, so we write to a free slot
                     for slot_index in range(0, 255):
                         slot = item_types_data[slot_index]
                         quantity = item_quantities_data[slot_index]

--- a/worlds/ff6wc/Client.py
+++ b/worlds/ff6wc/Client.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from typing_extensions import override
 
-from NetUtils import ClientStatus
+from NetUtils import ClientStatus, NetworkItem
 from Utils import async_start
 from worlds.AutoSNIClient import SNIClient
 
@@ -326,26 +326,45 @@ class FF6WCClient(SNIClient):
                     return
                 reserved_slots: list[int] = []
                 # Field items
+                # First, check if we already have the item in question in inventory
+                found_slot = -1
                 for i in range(0, 255):
                     slot = item_types_data[i]
-                    quantity = item_quantities_data[i]
-                    exists = False
                     if slot == Rom.item_name_id[item_name]:
-                        exists = True
-                    if (slot == 255 or quantity == 0 or exists is True) and quantity < 98:
-                        reserved_slots.append(i)
-                        type_destination = Rom.item_types_base_address + i
-                        amount_destination = Rom.item_quantities_base_address + i
-                        type_id = Rom.item_name_id[item_name]
-                        amount = quantity + 1
-                        snes_buffered_write(ctx, type_destination, bytes([type_id]))
-                        snes_buffered_write(ctx, amount_destination, bytes([amount]))
-                        self.increment_items_received(ctx, items_received_amount)
-                        snes_logger.info('Received %s from %s (%s)' % (
-                            item_name,
-                            ctx.player_names[item.player],
-                            ctx.location_names.lookup_in_slot(item.location, item.player)))
+                        found_slot = i
                         break
+                if found_slot != -1:
+                    type_destination = Rom.item_types_base_address + found_slot
+                    amount_destination = Rom.item_quantities_base_address + found_slot
+                    quantity = item_quantities_data[found_slot]
+                    amount = max(min(quantity + 1, 99), 0)
+                    type_id = Rom.item_name_id[item_name]
+                    self.add_item_to_inventory(ctx,
+                                               type_destination,
+                                               amount_destination,
+                                               items_received_amount,
+                                               type_id,
+                                               amount,
+                                               item_name,
+                                               item)
+                else: # Item not in inventory, so we write to a free slot
+                    for i in range(0, 255):
+                        slot = item_types_data[i]
+                        quantity = item_quantities_data[i]
+                        if (slot == 255 or quantity == 0):
+                            type_destination = Rom.item_types_base_address + i
+                            amount_destination = Rom.item_quantities_base_address + i
+                            type_id = Rom.item_name_id[item_name]
+                            amount = 1
+                            self.add_item_to_inventory(ctx,
+                                                       type_destination,
+                                                       amount_destination,
+                                                       items_received_amount,
+                                                       type_id,
+                                                       amount,
+                                                       item_name,
+                                                       item)
+                            break
 
     async def check_victory1(self, ctx: SNIContext) -> None:
         from SNIClient import snes_read
@@ -378,3 +397,20 @@ class FF6WCClient(SNIClient):
         from SNIClient import snes_buffered_write
         items_received_amount += 1
         snes_buffered_write(ctx, Rom.items_received_address, items_received_amount.to_bytes(2, 'little'))
+
+    def add_item_to_inventory(self, ctx: SNIContext,
+                                    type_destination: int,
+                                    amount_destination: int,
+                                    items_received_amount: int,
+                                    type_id: int,
+                                    amount: int,
+                                    item_name: str,
+                                    item: NetworkItem):
+        from SNIClient import snes_buffered_write
+        snes_buffered_write(ctx, type_destination, bytes([type_id]))
+        snes_buffered_write(ctx, amount_destination, bytes([amount]))
+        self.increment_items_received(ctx, items_received_amount)
+        snes_logger.info('Received %s from %s (%s)' % (
+            item_name,
+            ctx.player_names[item.player],
+            ctx.location_names.lookup_in_slot(item.location, item.player)))

--- a/worlds/ff6wc/Client.py
+++ b/worlds/ff6wc/Client.py
@@ -337,7 +337,7 @@ class FF6WCClient(SNIClient):
                     type_destination = Rom.item_types_base_address + found_slot
                     amount_destination = Rom.item_quantities_base_address + found_slot
                     quantity = item_quantities_data[found_slot]
-                    amount = max(min(quantity + 1, 99), 0)
+                    amount = max(min(quantity + 1, 99), 1)
                     type_id = Rom.item_name_id[item_name]
                     self.add_item_to_inventory(ctx,
                                                type_destination,


### PR DESCRIPTION
## What is this fixing or adding?
Fixing a bug where having empty slots in the middle of the inventory would cause duplicate item entries in the inventory.
Additionally, added a bounds check so that added items have a quantity between 1 and 99 because no other values make sense.

## How was this tested?
Connected the new client code, did some !getitems under the following circumstances:
- New item with first blank space after all other items. New item went into first blank space with quantity of one.
- New item with first blank space in between other items. New item went into first blank space with quantity of one.
- Existing item with first blank space after all other items. Added item increased quantity of existing item by one.
- Existing item with first blank space in between other items. Added item increased quantity of existing item by one.
