### PR TITLE
Added location scout hints

### DIFF
--- a/worlds/ff6wc/Client.py
+++ b/worlds/ff6wc/Client.py
@@ -9,7 +9,6 @@ from Utils import async_start
 from worlds.AutoSNIClient import SNIClient
 
 from . import Rom, Locations
-from .Rom import dialog_index_size
 from .id_maps import location_name_to_id
 from .patch import FF6WCPatch
 
@@ -423,7 +422,7 @@ class FF6WCClient(SNIClient):
 
     async def check_location_scouts(self, ctx: SNIContext):
         from SNIClient import snes_read
-        dialog_data = await snes_read(ctx, Rom.dialog_index_address, dialog_index_size)
+        dialog_data = await snes_read(ctx, Rom.dialog_index_address, Rom.dialog_index_size)
         if dialog_data is None:
             return
         dialog_index = int.from_bytes(dialog_data, "little")

--- a/worlds/ff6wc/Client.py
+++ b/worlds/ff6wc/Client.py
@@ -423,11 +423,16 @@ class FF6WCClient(SNIClient):
     async def check_location_scouts(self, ctx: SNIContext):
         from SNIClient import snes_read
         dialog_data = await snes_read(ctx, Rom.dialog_index_address, Rom.dialog_index_size)
+        map_data = await snes_read(ctx, Rom.map_index_address, 2)
+        if map_data is None:
+            return False
+        map_index = int.from_bytes(map_data, "little")
         if dialog_data is None:
             return
         dialog_index = int.from_bytes(dialog_data, "little")
-        if dialog_index in Rom.dialog_location_scouts_lookup.keys():
-            location_scout_list = Rom.dialog_location_scouts_lookup[dialog_index]
+        lookup = map_index, dialog_index
+        if lookup in Rom.dialog_location_scouts_lookup.keys():
+            location_scout_list = Rom.dialog_location_scouts_lookup[lookup]
             for location in location_scout_list:
                 location_id = self.location_ids[location]
                 if location_id not in ctx.locations_scouted:

--- a/worlds/ff6wc/Rom.py
+++ b/worlds/ff6wc/Rom.py
@@ -21,6 +21,8 @@ blitz_byte = 0xF51D28
 menu_address = 0xF50059
 formation_id = 0xF511E0
 animation_byte = 0xF5009A
+dialog_index_address = 0xF500D0
+dialog_index_size = 2
 
 espers = [  # This is the internal order of the Espers in the game. Editing this will break things.
     "Ramuh", "Ifrit", "Shiva",
@@ -639,6 +641,14 @@ treasure_chest_data: Dict[str, Tuple[int, int, int]] = {
     "Zozo Esper Room Right": (0x1E48, 7, 140)
 }
 
+dialog_location_scouts_lookup = {
+    1111: ["Auction House 10kGP"],
+    1115: ["Auction House 20kGP"],
+    1765: ["Lone Wolf 1", "Lone Wolf 2"],
+    1519: ["Narshe Weapon Shop 1", "Narshe Weapon Shop 2"],
+    1569: ["Tzen Thief"],
+    1570: ["Tzen Thief"], # This isn't an error. He's got two different dialogs depending on WoB vs WoR.
+}
 
 def get_event_flag_value(event_id: int) -> Tuple[int, int]:
     """ returns (address offset from `event_flag_base_address`, bit mask) """

--- a/worlds/ff6wc/Rom.py
+++ b/worlds/ff6wc/Rom.py
@@ -24,6 +24,7 @@ animation_byte = 0xF5009A
 dialog_index_address = 0xF500D0
 dialog_index_size = 2
 
+
 espers = [  # This is the internal order of the Espers in the game. Editing this will break things.
     "Ramuh", "Ifrit", "Shiva",
     "Siren", "Terrato", "Shoat",
@@ -642,12 +643,12 @@ treasure_chest_data: Dict[str, Tuple[int, int, int]] = {
 }
 
 dialog_location_scouts_lookup = {
-    1111: ["Auction House 10kGP"],
-    1115: ["Auction House 20kGP"],
-    1765: ["Lone Wolf 1", "Lone Wolf 2"],
-    1519: ["Narshe Weapon Shop 1", "Narshe Weapon Shop 2"],
-    1569: ["Tzen Thief"],
-    1570: ["Tzen Thief"], # This isn't an error. He's got two different dialogs depending on WoB vs WoR.
+    (200, 1111): ["Auction House 10kGP"],
+    (200, 1115): ["Auction House 20kGP"],
+    (23, 1765): ["Lone Wolf 1", "Lone Wolf 2"],
+    (24, 1519): ["Narshe Weapon Shop 1", "Narshe Weapon Shop 2"],
+    (306, 1569): ["Tzen Thief"],
+    (305, 1570): ["Tzen Thief"], # This isn't an error. He's got two different dialogs depending on WoB vs WoR.
 }
 
 def get_event_flag_value(event_id: int) -> Tuple[int, int]:


### PR DESCRIPTION
Added LocationScout hints when encountering some AP items ingame. Specifically, to Tzen Thief, Auction House, Narshe Weapon Shop, and Lone Wolf. This allows people to see what an `ArchplgoItem` is before making the decision to spend the money or choice. As a bonus, it leaves a record of what the other choice was for Weapon Shop and Lone Wolf, and stores the info scouted as a free server hint.

This was implemented by just checking the active dialog box index. In theory, this should be safe, but FF6 is a weird beast so there may be unanticipated false positives. We're only safe to read and write on the field so we should be fine, but testing will reveal, I'm sure. Additionally, due to how this was implemented, the scouts are not retroactive: if you don't have the client open and connected to the server while the dialog box is onscreen, the hint won't fire (though if you go back and see it again when you are it will, of course). I don't think this is a big impediment for players, all things considered, since other ingame functions also rely on the client being connected.