### PR TITLE
Add Scout for the Mobliz WoR spoiler girl.

### DIFF
--- a/worlds/ff6wc/Rom.py
+++ b/worlds/ff6wc/Rom.py
@@ -649,6 +649,8 @@ dialog_location_scouts_lookup = {
     (24, 1519): ["Narshe Weapon Shop 1", "Narshe Weapon Shop 2"],
     (306, 1569): ["Tzen Thief"],
     (305, 1570): ["Tzen Thief"],  # This isn't an error. He's got two different dialogs depending on WoB vs WoR.
+    (154, 2264): ["Mobliz"],  # The spoiler girl if Esper or Item.
+    (154, 2307): ["Mobliz"],  # The spoiler girl if Character.
 }
 
 


### PR DESCRIPTION
There's a little girl in Mobliz WoR that reveals what the reward for Mobliz is. Since this is possibly going to be ArchplgoItem, I am adding this as a Location Scout.
@rosalie-A recently added Location Scouts. @BriGuy7727 suggested this scout be added, as WC players frequently use this girl to determine if this boss should even be defeated.

## What is this fixing or adding?
Add the spoiler girl, so she tells the player what will be rewarded upon defeating the boss in Mobliz WoR.
![Screenshot 2025-06-24 at 1 18 29 AM](https://github.com/user-attachments/assets/7943e44f-8b08-493d-81fb-7b32a481fdd8)

![Screenshot 2025-06-24 at 1 34 48 AM](https://github.com/user-attachments/assets/42f34555-603f-4da5-9681-49777d1a440d)



